### PR TITLE
Fix baseline to process entity markup

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,20 @@ the test portion.
 
 Run `train_and_predict.py` to start training and prediction. The script expects
 training data in `data/train_data.csv` and evaluation data in
-`data/test_data.csv` (tab separated). After training the best checkpoint is saved
-inside `checkpoints/` and predictions are written to `prediction.csv` with
+`data/test_data.csv` (tab separated). Each record contains the following
+columns:
+
+- `sentence` – the full sentence containing the target entity;
+- `entity` – entity text;
+- `entity_tag` – one of `PERSON`, `ORGANIZATION`, `PROFESSION`, `COUNTRY`,
+  `NATIONALITY`;
+- `entity_pos_start_rel` and `entity_pos_end_rel` – character offsets of the
+  entity inside the sentence;
+- `label` – sentiment label (−1 – negative, 0 – neutral, 1 – positive).
+
+During preprocessing the entity span is highlighted with the tokens `<ent>` and
+`</ent>` before feeding text to the model. After training the best checkpoint is
+saved inside `checkpoints/` and predictions are written to `prediction.csv` with
 columns `id` and `label`.
 
 Example:


### PR DESCRIPTION
## Summary
- preprocess entity spans with `<ent>` tokens during tokenization
- resize embeddings for added special tokens
- document the new dataset structure and preprocessing steps

## Testing
- `python -m py_compile train_and_predict.py`